### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -46,7 +46,7 @@ class syntax_plugin_flowcharts extends DokuWiki_Syntax_Plugin
     /**
      * Handle matches of the flowcharts syntax
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
         switch ($state) {
             case DOKU_LEXER_ENTER:
                 $data = strtolower(trim(substr($match,6,-1)));
@@ -66,7 +66,7 @@ class syntax_plugin_flowcharts extends DokuWiki_Syntax_Plugin
     /**
      * Render xhtml output or metadata
      */
-    function render($mode, &$renderer, $indata) {
+    function render($mode, Doku_Renderer $renderer, $indata) {
         if($mode == 'xhtml'){
             list($state, $match) = $indata;
             switch ($state) {


### PR DESCRIPTION
Starting with PHP 7, classes that overdrive methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error. This commit fixes it.