### PR TITLE
support for basic dokuwiki syntax inside flowchart blocks

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   flowcharts
 author Jakob Schwichtenberg
 email  mail@jakobschwichtenberg.com
-date   2018-04-28
+date   2018-06-15
 name   flowcharts Plugin
 desc   Create flowcharts and diagrams with an incredibly simple syntax
 url    https://www.dokuwiki.org/plugin:flowcharts

--- a/renderer.php
+++ b/renderer.php
@@ -1,0 +1,75 @@
+<?php
+
+class renderer_plugin_flowcharts extends Doku_Renderer_xhtml {
+    function underline_open() {
+        $xhtml = '<em class="u">';
+
+        $xhtml = htmlentities($xhtml,ENT_NOQUOTES);
+        $xhtml = str_replace(array('"', '='), array('&#39;', '&#61;'), $xhtml);
+
+        $this->doc .= $xhtml;
+    }
+
+    function underline_close() {
+        $xhtml = '</em>';
+
+        $xhtml = htmlentities($xhtml,ENT_NOQUOTES);
+        $xhtml = str_replace(array('"', '='), array('&#39;', '&#61;'), $xhtml);
+
+        $this->doc .= $xhtml;
+    }
+
+    function internallink($id, $name = null, $search = null, $returnonly = false, $linktype = 'content') {
+        $xhtml = parent::internallink($id, $name, $search, true, $linktype);
+
+
+        $xhtml = htmlentities($xhtml,ENT_NOQUOTES);
+        $xhtml = str_replace(array('"', '='), array('&#39;', '&#61;'), $xhtml);
+
+        //output formatted
+        if($returnonly) {
+            return $xhtml;
+        } else {
+            $this->doc .= $xhtml;
+        }
+    }
+
+    function externallink($url, $name = null, $returnonly = false) {
+        $xhtml = parent::externallink($url, $name = null, true);
+
+
+        $xhtml = htmlentities($xhtml,ENT_NOQUOTES);
+        $xhtml = str_replace(array('"', '='), array('&#39;', '&#61;'), $xhtml);
+
+        //output formatted
+        if($returnonly) {
+            return $xhtml;
+        } else {
+            $this->doc .= $xhtml;
+        }
+    }
+
+    function internalmedia($src, $title = null, $align = null, $width = null,
+                           $height = null, $cache = null, $linking = null, $return = false) {
+        $xhtml = parent::internalmedia($src, $title, $align, $width, $height, $cache, $linking, true);
+
+        $xhtml = htmlentities($xhtml,ENT_NOQUOTES);
+        $xhtml = str_replace(array('"', '='), array('&#39;', '&#61;'), $xhtml);
+
+        //output formatted
+        if($return) {
+            return $xhtml;
+        } else {
+            $this->doc .= $xhtml;
+        }
+    }
+
+    /**
+     * Render plain text data
+     *
+     * @param $text
+     */
+    function cdata($text) {
+        $this->doc .= $text;
+    }
+}

--- a/syntax.php
+++ b/syntax.php
@@ -23,9 +23,6 @@ class syntax_plugin_flowcharts extends DokuWiki_Syntax_Plugin
     // must return a number lower than returned by native 'code' mode (200)
     function getSort(){ return 158; }
 
-    
-    
-
     /**
      * Connect lookup pattern to lexer.
      *
@@ -67,20 +64,90 @@ class syntax_plugin_flowcharts extends DokuWiki_Syntax_Plugin
             switch ($state) {
  
             case DOKU_LEXER_ENTER :      
-                $renderer->doc .= '<div class="mermaid">';
-                break;
- 
-              case DOKU_LEXER_UNMATCHED : 
-                $renderer->doc .= $match;
-                break;
- 
+                  $renderer->doc .= '<div class="mermaid">';
+                  break;
+              case DOKU_LEXER_UNMATCHED :
+                  $instructions = $this->p_get_instructions($match);
+                  $xhtml = $this->p_render($instructions);
+                  $renderer->doc .= $xhtml;
+                  break;
               case DOKU_LEXER_EXIT :
-                $renderer->doc .= "</div>";
-                break;
+                  $renderer->doc .= "</div>";
+                  break;
             }
             return true;
         }
         return false;
+    }
+
+    /*
+     * Get the parser instructions siutable for the mermaid
+     *
+     */
+    function p_get_instructions($text) {
+
+        $modes = array();
+
+        // add default modes
+        $std_modes = array('internallink', 'media','externallink');
+
+        foreach($std_modes as $m){
+            $class = "Doku_Parser_Mode_$m";
+            $obj   = new $class();
+            $modes[] = array(
+                'sort' => $obj->getSort(),
+                'mode' => $m,
+                'obj'  => $obj
+            );
+        }
+
+        // add formatting modes
+        $fmt_modes = array('strong','emphasis','underline','monospace',
+                           'subscript','superscript','deleted');
+        foreach($fmt_modes as $m){
+            $obj   = new Doku_Parser_Mode_formatting($m);
+            $modes[] = array(
+                'sort' => $obj->getSort(),
+                'mode' => $m,
+                'obj'  => $obj
+            );
+        }
+
+        // Create the parser
+        $Parser = new Doku_Parser();
+
+        // Add the Handler
+        $Parser->Handler = new Doku_Handler();
+
+        //add modes to parser
+        foreach($modes as $mode){
+            $Parser->addMode($mode['mode'],$mode['obj']);
+        }
+        $Parser->connectModes();
+
+        $Parser->Lexer->parse($text);
+
+        // Do the parsing
+        return $Parser->Handler->calls;
+    }
+
+    public function p_render($instructions) {
+        $Renderer = p_get_renderer('flowcharts');
+
+        $Renderer->smileys = getSmileys();
+        $Renderer->entities = getEntities();
+        $Renderer->acronyms = getAcronyms();
+        $Renderer->interwiki = getInterwiki();
+
+        // Loop through the instructions
+        foreach ( $instructions as $instruction ) {
+            // Execute the callback against the Renderer
+            if(method_exists($Renderer, $instruction[0])){
+                call_user_func_array(array(&$Renderer, $instruction[0]), $instruction[1] ? $instruction[1] : array());
+            }
+        }
+
+        return $Renderer->doc;
     }
 
 }


### PR DESCRIPTION
Since the mermaid has some problems with html, this solution may
not be prefectly relible but it's very useful from my point of view.

Currently supported syntax modes:
  'strong'
  'emphasis'
  'underline'
  'monospace'
  'subscript'
  'superscript'
  'deleted'
  'internallink'
  'media'
  'externallink'