### PR TITLE
Fix mermaidAPI reference error

### DIFF
--- a/action.php
+++ b/action.php
@@ -18,19 +18,18 @@ class action_plugin_flowcharts extends DokuWiki_Action_Plugin
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this,
                                    '_loadmermaid');
     }
- 
+
     public function _loadmermaid(Doku_Event $event, $param) {
         $event->data['script'][] = array(
                             'type'    => 'text/javascript',
                             'charset' => 'utf-8',
                             '_data'   => '',
                             'src' => DOKU_BASE."lib/plugins/flowcharts/mermaid.min.js");
-        
+
         $event->data['script'][] = array(
-                            'type'    => 'text/javascript',
-                            'charset' => 'utf-8',
-                            '_data'   => '',
-                            'src' => DOKU_BASE."lib/plugins/flowcharts/mermaid-init.js");
+                    'type'    => 'text/javascript',
+                    'charset' => 'utf-8',
+                    '_data'   => 'mermaid.initialize({securityLevel: "loose"});');
 
         $event->data['link'][] = array (
                             'rel'     => 'stylesheet',

--- a/deleted.files
+++ b/deleted.files
@@ -1,0 +1,5 @@
+# This is a list of files that were present in previous plugin releases
+# but were removed later. An up to date plugin should not have any of
+# the files installed
+
+mermaid-init.js

--- a/mermaid-init.js
+++ b/mermaid-init.js
@@ -1,3 +1,0 @@
-mermaidAPI.initialize({
-	securityLevel: 'loose'
-});


### PR DESCRIPTION
This commit moves the mermaid.initialize call from external file into the HTML page content. This fixes the problem with mermaidAPI reference error.