### PR TITLE
fix rendering process when cache is used

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -90,6 +90,9 @@ class syntax_plugin_flowcharts extends DokuWiki_Syntax_Plugin
      */
     function p_get_instructions($text) {
 
+        //import parser classes and mode definitions
+        require_once DOKU_INC . 'inc/parser/parser.php';
+
         $modes = array();
 
         // add default modes


### PR DESCRIPTION
This commit fixes plugin syntax rendering when dokuwiki page cache is used.